### PR TITLE
Fix plugin detection for Windows build

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -52,5 +52,9 @@ add_subdirectory(${FLUTTER_MANAGED_DIR}/flutter)
 # Application build
 add_subdirectory("runner")
 
-# Generated plugin build rules.
-include(flutter/generated_plugins.cmake)
+# Generated plugin build rules with fallback to a fixed version.
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/flutter/generated_plugins_fixed.cmake")
+  include(flutter/generated_plugins_fixed.cmake)
+else()
+  include(flutter/generated_plugins.cmake)
+endif()

--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -41,7 +41,11 @@ set_target_properties(${BINARY_NAME}
 
 # Generated plugin build rules, which manage building the plugins and adding
 # them to the application.
-include(../flutter/generated_plugins.cmake)
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../flutter/generated_plugins_fixed.cmake")
+  include(../flutter/generated_plugins_fixed.cmake)
+else()
+  include(../flutter/generated_plugins.cmake)
+endif()
 
 # === Installation ===
 # Support files are copied into place next to the executable, so that it can


### PR DESCRIPTION
## Summary
- include `generated_plugins_fixed.cmake` when available
- fallback to the default generated plugins file otherwise

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c29c8f21c832ab25aca9bd2ebdc45