### PR TITLE
Fix GitHub Actions Windows build

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -31,8 +31,9 @@ jobs:
     - name: Apply GitHub Actions Plugin Fix
       run: |
         echo "🔧 Applying GitHub Actions CMake plugin fix..."
-        Copy-Item -Path "windows/flutter/generated_plugins_github_actions_fixed.cmake" -Destination "windows/flutter/generated_plugins.cmake" -Force
-        echo "✅ Copied 'generated_plugins_github_actions_fixed.cmake' to 'generated_plugins.cmake'"
+        Copy-Item -Path "windows/flutter/generated_plugins_fixed.cmake" -Destination "windows/flutter/generated_plugins.cmake" -Force
+        powershell -ExecutionPolicy Bypass -File "windows/create_plugin_stubs.ps1"
+        echo "✅ Plugin stubs created and generated_plugins.cmake updated"
     
     - name: Build Windows Release
       run: flutter build windows --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,13 @@ jobs:
       
     - name: Get dependencies
       run: flutter pub get
+
+    - name: Apply GitHub Actions Plugin Fix
+      run: |
+        echo "🔧 Applying GitHub Actions CMake plugin fix..."
+        Copy-Item -Path "windows/flutter/generated_plugins_fixed.cmake" -Destination "windows/flutter/generated_plugins.cmake" -Force
+        powershell -ExecutionPolicy Bypass -File "windows/create_plugin_stubs.ps1"
+        echo "✅ Plugin stubs created and generated_plugins.cmake updated"
       
     - name: Build Windows app
       run: flutter build windows --release

--- a/apply_github_actions_fix.sh
+++ b/apply_github_actions_fix.sh
@@ -11,7 +11,7 @@ if [ -f "windows/flutter/generated_plugins.cmake" ]; then
 fi
 
 # Copy our GitHub Actions compatible version
-cp "windows/flutter/generated_plugins_github_actions_fixed.cmake" "windows/flutter/generated_plugins.cmake"
+cp "windows/flutter/generated_plugins_fixed.cmake" "windows/flutter/generated_plugins.cmake"
 echo "✅ Applied GitHub Actions compatible generated_plugins.cmake"
 
 # Make the file read-only to prevent Flutter from overwriting it


### PR DESCRIPTION
## Summary
- update GitHub Actions workflows to create plugin stubs and use the fixed `generated_plugins.cmake`
- adjust helper script to copy the correct CMake plugin file

## Testing
- `flutter test` *(fails: command not found)*
- `cd windows && cmake -B build -S .`

------
https://chatgpt.com/codex/tasks/task_e_684c5aa413e4832a87decff034c7df9d