### PR TITLE
Update plugin stub script path

### DIFF
--- a/windows/create_plugin_stubs.ps1
+++ b/windows/create_plugin_stubs.ps1
@@ -4,11 +4,14 @@
 
 Write-Host "Creating plugin stubs for GitHub Actions..." -ForegroundColor Green
 
+# Determine the directory of this script
+$scriptDir = $PSScriptRoot
+
 # Define plugin list (from pubspec.yaml dependencies)
 $plugins = @("webview_windows")
 
 foreach ($plugin in $plugins) {
-    $pluginDir = "flutter\ephemeral\.plugin_symlinks\$plugin\windows"
+    $pluginDir = Join-Path $scriptDir "flutter/ephemeral/.plugin_symlinks/$plugin/windows"
 
     Write-Host "Creating directory: $pluginDir" -ForegroundColor Yellow
     New-Item -ItemType Directory -Force -Path $pluginDir | Out-Null


### PR DESCRIPTION
## Summary
- initialize `$scriptDir` for create_plugin_stubs.ps1
- use `Join-Path` with `$scriptDir` when creating plugin directories

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c64300150832a87c2c5ece0d22778