### PR TITLE
Fix windows build workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -36,7 +36,7 @@ jobs:
         echo "Plugin stubs created and generated_plugins.cmake updated"
     
     - name: Build Windows Release
-      run: flutter build windows --release
+      run: flutter build windows --release --no-pub
     
     - name: Upload Windows Build
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         echo "Plugin stubs created and generated_plugins.cmake updated"
       
     - name: Build Windows app
-      run: flutter build windows --release
+      run: flutter build windows --release --no-pub
       
     - name: Create portable package
       run: |

--- a/BROWSER_README.md
+++ b/BROWSER_README.md
@@ -140,7 +140,11 @@ flutter test integration_test/
 
 ### Building Release Version
 ```bash
+# Local build
 flutter build windows --release
+
+# CI build
+flutter build windows --release --no-pub
 ```
 
 ### Creating Installer

--- a/DEVELOPER_DOCS.md
+++ b/DEVELOPER_DOCS.md
@@ -117,6 +117,8 @@ flutter run -d windows --debug
 #### Release Build
 ```bash
 flutter build windows --release
+# CI build
+flutter build windows --release --no-pub
 ```
 
 #### CMake Direct Build
@@ -325,7 +327,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - run: flutter test
-      - run: flutter build windows
+      - run: flutter build windows --no-pub
 ```
 
 ### Build Artifacts

--- a/FINAL_CMAKE_PLUGIN_FIX_v1.0.7.md
+++ b/FINAL_CMAKE_PLUGIN_FIX_v1.0.7.md
@@ -78,7 +78,7 @@ cmake -B build -S .
 - Debug messaging system functional
 
 ### **✅ GitHub Actions Compatibility:**
-The enhanced solution ensures `flutter build windows --release` will succeed in GitHub Actions by:
+The enhanced solution ensures `flutter build windows --release --no-pub` will succeed in GitHub Actions by:
 - Creating stub plugins when real directories are missing
 - Maintaining build compatibility across environments
 - Providing fallback implementations for all required exports
@@ -105,7 +105,7 @@ The enhanced solution ensures `flutter build windows --release` will succeed in 
 
 The Focus Browser project now has **complete GitHub Actions compatibility** with our enhanced CMake plugin system. The build process will succeed in CI/CD environments regardless of plugin directory availability.
 
-**Build Command Ready:** `flutter build windows --release` ✅  
+**Build Command Ready:** `flutter build windows --release --no-pub` ✅
 **GitHub Actions Ready:** CMake configuration passes ✅  
 **Plugin System:** Enhanced with stub generation ✅  
 

--- a/GITHUB_ACTIONS_CMAKE_FIX_v1.0.8.md
+++ b/GITHUB_ACTIONS_CMAKE_FIX_v1.0.8.md
@@ -50,7 +50,7 @@ add_subdirectory given source 'flutter/ephemeral/.plugin_symlinks/webview_window
     powershell -ExecutionPolicy Bypass -File "create_plugin_stubs.ps1"
 
 - name: Build Windows Release
-  run: flutter build windows --release
+  run: flutter build windows --release --no-pub
 ```
 
 ### 3. Enhanced Plugin Detection

--- a/HOTFIX_v1.0.4_CMAKE_BUILD_FIX.md
+++ b/HOTFIX_v1.0.4_CMAKE_BUILD_FIX.md
@@ -64,6 +64,7 @@ windows/
 GitHub Actions теперь должны успешно выполнить:
 ```bash
 flutter build windows --release
+flutter build windows --release --no-pub
 ```
 
 Если сборка пройдет успешно, будет создан:

--- a/PROJECT_COMPLETION_v1.0.5.md
+++ b/PROJECT_COMPLETION_v1.0.5.md
@@ -104,7 +104,7 @@ windows/                  # Windows сборка
 - Все CMake ошибки исправлены
 - Плагин webview_windows настроен
 - Fallback системы реализованы
-- **Команда сборки:** `flutter build windows --release`
+- **Команда сборки:** `flutter build windows --release --no-pub`
 
 ### ✅ GitHub Actions:
 - Автоматическая сборка настроена

--- a/README_EN.md
+++ b/README_EN.md
@@ -43,8 +43,11 @@ flutter pub get
 # Development
 flutter run -d windows
 
-# Production Release
+# Production Release (local)
 flutter build windows --release
+
+# CI/CD (skip pub get)
+flutter build windows --release --no-pub
 ```
 
 ## 📚 Complete Documentation Suite
@@ -186,6 +189,8 @@ git push origin feature/new-awesome-feature
 # Local build test
 flutter build windows --debug
 flutter build windows --release
+# CI build
+flutter build windows --release --no-pub
 
 # CMake direct test
 cd windows && cmake --build build --config Release


### PR DESCRIPTION
## Summary
- prevent Flutter from re-running `pub get` in CI
- update docs for new CI build command

## Testing
- `bash test_cmake_fix.sh` *(fails: project command is not scriptable)*

------
https://chatgpt.com/codex/tasks/task_e_684c6a2cd078832ab85d601fccb17e0f