### PR TITLE
Fix singbox_manager syntax

### DIFF
--- a/lib/singbox_manager.dart
+++ b/lib/singbox_manager.dart
@@ -3,17 +3,7 @@ import 'dart:convert';
 import 'package:path/path.dart' as path;
 import 'logger.dart';
 
-//           i        AppLogger.info('sing-box started with PID: ${_singBoxProcess!.pid}'); (_singBoxProcess != null) {
-        _isRunning = true;
-        AppLogger.info('sing-box started with PID: ${_singBoxProcess!.pid}');
-
-        // Improved output buffering
-        _singBoxProcess!.stdout.transform(utf8.decoder).listen((data) {singBoxProcess != null) {
-        _isRunning = true;
-        AppLogger.info('sing-box started with PID: ${_singBoxProcess!.pid}');
-
-        // Improved output buffering
-        _singBoxProcess!.stdout.transform(utf8.decoder).listen((data) {nager class for controlling the sing-box proxy service
+/// Manager class for controlling the sing-box proxy service
 class SingBoxManager {
   static Process? _singBoxProcess;
   static bool _isRunning = false;


### PR DESCRIPTION
## Summary
- clean up garbage lines at top of `SingBoxManager`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c835eccf8832ab5e76b85f29c6a92